### PR TITLE
Updating default Rubocop config

### DIFF
--- a/lib/commitment/generators/templates/.hound.yml
+++ b/lib/commitment/generators/templates/.hound.yml
@@ -18,7 +18,9 @@ AllCops:
     - 'vendor/**/*'
     - 'tmp/**/*'
     - 'bin/**/*'
-  RunRailsCops: true
+
+Rails:
+  Enabled: true
 
 LineLength:
   Description: 'Limit lines to 140 characters.'


### PR DESCRIPTION
The syntax for declaring that a project is a rails application has changed.