### PR TITLE
Allow override to expected coverage

### DIFF
--- a/lib/commitment.rb
+++ b/lib/commitment.rb
@@ -14,7 +14,7 @@ module Commitment
     attr_reader :jshint_exclude_pattern
     attr_reader :jshint_options
     attr_reader :scss_lint_config
-    attr_reader :percentage_coverage_goal
+    attr_accessor :percentage_coverage_goal
     attr_reader :code_coverage_last_run_pathname
 
     def initialize

--- a/lib/commitment/tasks/code_coverage.rake
+++ b/lib/commitment/tasks/code_coverage.rake
@@ -6,7 +6,7 @@ namespace :commitment do
     $stdout.puts "Checking commitment:code_coverage"
     coverage_percentage = Commitment.config.code_coverage_last_run_results.fetch('result').fetch('covered_percent').to_i
     if Commitment.config.percentage_coverage_goal > coverage_percentage
-      abort("Code Coverage Goal Not Met:\n\t#{coverage_percentage}%\tExpected\n\t#{Commitment.config.percentage_coverage_goal}%\tActual")
+      abort("Code Coverage Goal Not Met:\n\t#{Commitment.config.percentage_coverage_goal}%\tExpected\n\t#{coverage_percentage}%\tActual")
     end
   end
 end


### PR DESCRIPTION
This exposes a way to set the expected coverage in an initializer.
```
Commitment.config.percentage_coverage_goal = 50
```

The labels on the printout of expected vs actual test coverage were reversed.