### PR TITLE
Migrate TravisCI to GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,28 @@
+name: Ruby CI
+
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby: [2.4, 2.5, 2.6]
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+      uses: ruby/setup-ruby@v1
+      # uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install minitest
+      run: gem install minitest
+    - name: Run tests
+      run: ruby test/commitment_test.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-rvm:
-  - 2.2.1
-  - 2.2.2

--- a/test/commitment_test.rb
+++ b/test/commitment_test.rb
@@ -1,4 +1,4 @@
-require 'minitest_helper'
+require_relative 'minitest_helper'
 require 'pathname'
 class TestCommitment < Minitest::Test
   def test_that_it_has_a_version_number


### PR DESCRIPTION
As part of both the introduction of GitHub Actions as well as the consolidation of TravisCI to eh .com domain and the required updates to webhooks and/or repository settings, the ndlib organization decided to migrate TravisCI runners to GitHub Actions as soon as possible.

This PR represents both that effort as well as what appears to be an initial setup of running unit tests on push and PRs against the `master` branch. Unfortunately, Ruby 2.4 is  the earliest native offering within GitHub Actions. If we require the tests to be run against earlier versions, we will need to either add runners to test within Docker containers that have those environments set up, or investigate options with `rvm` or `rbenv` within the runners.